### PR TITLE
Allow access to 'java.lang' automatically

### DIFF
--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
@@ -22,6 +22,7 @@ import org.moditect.deptective.internal.model.Package;
 import org.moditect.deptective.internal.model.PackageDependencies;
 
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodTree;
@@ -72,6 +73,8 @@ public class DeptectiveTreeVisitor extends TreePathScanner<Void, Void> {
         return super.visitCompilationUnit(tree, p);
     }
 
+
+
     //    @Override
     //    public Void visitImport(ImportTree node, Void p) {
     // TODO: Deal with "on-demand-imports" (com.foo.*)
@@ -85,6 +88,18 @@ public class DeptectiveTreeVisitor extends TreePathScanner<Void, Void> {
     //        checkPackageAccess(node, getQualifiedName(node.getQualifiedIdentifier()));
     //        return super.visitImport(node, p);
     //    }
+
+    @Override
+    public Void visitClass(ClassTree node, Void p) {
+        Tree extendsClause = node.getExtendsClause();
+        if (extendsClause != null) {
+            checkPackageAccess(extendsClause, getQualifiedName(extendsClause));
+        }
+
+        node.getImplementsClause().forEach(implementsClause -> checkPackageAccess(implementsClause, getQualifiedName(implementsClause)));
+
+        return super.visitClass(node, p);
+    }
 
     @Override
     public Void visitVariable(VariableTree node, Void p) {
@@ -137,8 +152,6 @@ public class DeptectiveTreeVisitor extends TreePathScanner<Void, Void> {
         checkPackageAccess(node, getQualifiedName(node));
         return super.visitNewClass(node, p);
     }
-
-
 
     @Override
     public Void visitMethod(MethodTree node, Void p) {

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
@@ -24,6 +24,7 @@ import org.moditect.deptective.internal.model.PackageDependencies;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
@@ -135,6 +136,17 @@ public class DeptectiveTreeVisitor extends TreePathScanner<Void, Void> {
     public Void visitNewClass(NewClassTree node, Void p) {
         checkPackageAccess(node, getQualifiedName(node));
         return super.visitNewClass(node, p);
+    }
+
+
+
+    @Override
+    public Void visitMethod(MethodTree node, Void p) {
+        Tree returnType = node.getReturnType();
+        if (returnType != null) {
+            checkPackageAccess(returnType, getQualifiedName(returnType));
+        }
+        return super.visitMethod(node, p);
     }
 
     protected String getQualifiedName(Tree tree) {

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveTreeVisitor.java
@@ -175,6 +175,10 @@ public class DeptectiveTreeVisitor extends TreePathScanner<Void, Void> {
     protected void checkPackageAccess(Tree node, String qualifiedName) {
         com.sun.tools.javac.tree.JCTree jcTree = (com.sun.tools.javac.tree.JCTree)node;
 
+        if ("java.lang".equals(qualifiedName)) {
+            return;
+        }
+
         if (packageDependencies.isWhitelisted(qualifiedName)) {
             return;
         }

--- a/javac-plugin/src/test/java/org/moditect/deptective/config/ConfigParsingTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/config/ConfigParsingTest.java
@@ -44,7 +44,7 @@ public class ConfigParsingTest {
                 "        }\n" +
                 "    ],\n" +
                 "    \"whitelisted\" : [\n" +
-                "        \"java.lang*\", \"java.util*\"\n" +
+                "        \"java.awt*\", \"java.util*\"\n" +
                 "    ]\n" +
                 "}\n")
                .getPackageDependencies();
@@ -61,8 +61,8 @@ public class ConfigParsingTest {
         assertThat(service.reads("com.example.ui")).isFalse();
         assertThat(service.reads("com.example.persistence")).isTrue();
 
-        assertThat(dependencies.isWhitelisted("java.lang")).isTrue();
-        assertThat(dependencies.isWhitelisted("java.lang.reflect")).isTrue();
+        assertThat(dependencies.isWhitelisted("java.awt")).isTrue();
+        assertThat(dependencies.isWhitelisted("java.awt.color")).isTrue();
         assertThat(dependencies.isWhitelisted("java.util.concurrent")).isTrue();
         assertThat(dependencies.isWhitelisted("java.io")).isFalse();
     }

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
@@ -51,6 +51,32 @@ public class BasicPluginTest extends PluginTestBase {
     }
 
     @Test
+    public void shouldDetectInvalidSuperClass() {
+        Compilation compilation = compile();
+        assertThat(compilation).failed();
+
+        assertThat(compilation).hadErrorContaining(
+                "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barsuper");
+
+        // inner class
+        assertThat(compilation).hadErrorContaining(
+                "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barinnersuper");
+    }
+
+    @Test
+    public void shouldDetectInvalidImplementedInterface() {
+        Compilation compilation = compile();
+        assertThat(compilation).failed();
+
+        assertThat(compilation).hadErrorContaining(
+                "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barinter");
+
+        // inner interface
+        assertThat(compilation).hadErrorContaining("package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barinnerinner");
+    }
+
+
+    @Test
     public void shouldDetectInvalidConstructorParameters() {
         Compilation compilation = compile();
         assertThat(compilation).failed();

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
@@ -27,6 +27,7 @@ import org.moditect.deptective.plugintest.basic.barparameter.BarParameter;
 import org.moditect.deptective.plugintest.basic.barretval.BarRetVal;
 import org.moditect.deptective.plugintest.basic.bartypearg.BarTypeArg;
 import org.moditect.deptective.plugintest.basic.foo.Foo;
+import org.moditect.deptective.plugintest.basic.foo.FooWithoutErrors;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
@@ -51,6 +52,14 @@ public class BasicPluginTest extends PluginTestBase {
     }
 
     @Test
+    public void shouldAllowAccessToJavaLangAutomatically() {
+        Compilation compilation = Compiler.javac()
+                .withOptions("-Xplugin:Deptective", getConfigFileOption())
+                .compile(forTestClass(FooWithoutErrors.class));
+        assertThat(compilation).succeeded();
+    }
+
+    @Test
     public void shouldDetectInvalidSuperClass() {
         Compilation compilation = compile();
         assertThat(compilation).failed();
@@ -66,7 +75,6 @@ public class BasicPluginTest extends PluginTestBase {
     @Test
     public void shouldDetectInvalidImplementedInterface() {
         Compilation compilation = compile();
-        assertThat(compilation).failed();
 
         assertThat(compilation).hadErrorContaining(
                 "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barinter");

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/BasicPluginTest.java
@@ -115,17 +115,20 @@ public class BasicPluginTest extends PluginTestBase {
                 "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barfieldan");
     }
 
-//    @Test
-//    public void shouldDetectInvalidReturnValueReferences() {
-//    	Compilation compilation = compile();
-//    	assertThat(compilation).failed();
-//
-//        // TODO https://github.com/moditect/deptective/issues/7
-//    	assertThat(compilation).hadErrorContaining(
-//    			"package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barretval"
-//    	);
-//
-//    }
+    @Test
+    public void shouldDetectInvalidReturnValueReferences() {
+    	Compilation compilation = compile();
+    	assertThat(compilation).failed();
+
+    	assertThat(compilation).hadErrorContaining(
+    			"package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barretval"
+    	);
+
+    	// Invalid Reference in Type Parameter
+    	assertThat(compilation).hadErrorContaining(
+                "package org.moditect.deptective.plugintest.basic.foo does not read org.moditect.deptective.plugintest.basic.barretvalgen"
+        );
+    }
 
     @Test
     public void shouldDetectInvalidTypeArguments() {

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinnerinner/BarInnerInterface.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinnerinner/BarInnerInterface.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.barinnerinner;
+
+public interface BarInnerInterface {
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinnersuper/BarInnerSuperClass.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinnersuper/BarInnerSuperClass.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.barinnersuper;
+
+public class BarInnerSuperClass {
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinter/BarInterface.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barinter/BarInterface.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.barinter;
+
+public interface BarInterface {
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barretvalgen/RetValGen.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barretvalgen/RetValGen.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.barretvalgen;
+
+public class RetValGen {
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barsuper/BarSuper.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/barsuper/BarSuper.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.barsuper;
+
+public class BarSuper {
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/Foo.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/Foo.java
@@ -29,6 +29,7 @@ import org.moditect.deptective.plugintest.basic.barlocalvar.BarLocalVar;
 import org.moditect.deptective.plugintest.basic.barloopvar.BarLoopVar;
 import org.moditect.deptective.plugintest.basic.barparameter.BarParameter;
 import org.moditect.deptective.plugintest.basic.barretval.BarRetVal;
+import org.moditect.deptective.plugintest.basic.barretvalgen.RetValGen;
 import org.moditect.deptective.plugintest.basic.bartypearg.BarTypeArg;
 
 @FooAnnotation
@@ -55,6 +56,11 @@ public class Foo {
 
         return null;
     }
+
+    private boolean isAllowed() { return true; }
+    private void isAlsoAllowed() { }
+
+    private List<RetValGen> isNotAllowed() { return null; }
 
     static class InvalidFooGeneric<T extends BarGeneric> {}
 

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/Foo.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/Foo.java
@@ -25,16 +25,20 @@ import org.moditect.deptective.plugintest.basic.barfield.BarField;
 import org.moditect.deptective.plugintest.basic.barfieldan.BarFieldAnnotation;
 import org.moditect.deptective.plugintest.basic.bargen.BarGeneric;
 import org.moditect.deptective.plugintest.basic.bargentype.BarGenType;
+import org.moditect.deptective.plugintest.basic.barinnerinner.BarInnerInterface;
+import org.moditect.deptective.plugintest.basic.barinnersuper.BarInnerSuperClass;
+import org.moditect.deptective.plugintest.basic.barinter.BarInterface;
 import org.moditect.deptective.plugintest.basic.barlocalvar.BarLocalVar;
 import org.moditect.deptective.plugintest.basic.barloopvar.BarLoopVar;
 import org.moditect.deptective.plugintest.basic.barparameter.BarParameter;
 import org.moditect.deptective.plugintest.basic.barretval.BarRetVal;
 import org.moditect.deptective.plugintest.basic.barretvalgen.RetValGen;
+import org.moditect.deptective.plugintest.basic.barsuper.BarSuper;
 import org.moditect.deptective.plugintest.basic.bartypearg.BarTypeArg;
 
 @FooAnnotation
 @BarClazzAnnotation
-public class Foo {
+public class Foo extends BarSuper implements BarInterface, /* allowed: */ IFoo {
 
 	@BarFieldAnnotation
     private String s;
@@ -65,4 +69,12 @@ public class Foo {
     static class InvalidFooGeneric<T extends BarGeneric> {}
 
     static class InvalidFooImplementation extends FooContainer<BarGenType> {}
+
+    static interface InnerFoo extends BarInnerInterface {
+
+    }
+
+    static class InnerFooClass extends BarInnerSuperClass {
+
+    }
 }

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/FooWithoutErrors.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/FooWithoutErrors.java
@@ -1,0 +1,9 @@
+package org.moditect.deptective.plugintest.basic.foo;
+
+public class FooWithoutErrors {
+
+    private String allowed;
+
+    private Iterable<Float> alsoAllowed;
+
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/IFoo.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/basic/foo/IFoo.java
@@ -1,0 +1,5 @@
+package org.moditect.deptective.plugintest.basic.foo;
+
+public interface IFoo {
+
+}

--- a/javac-plugin/src/test/resources/org/moditect/deptective/plugintest/basic/deptective.json
+++ b/javac-plugin/src/test/resources/org/moditect/deptective/plugintest/basic/deptective.json
@@ -24,7 +24,6 @@
         {
             "name" : "org.moditect.deptective.plugintest.basic.foo",
             "reads" : [
-                "java.lang",
                 "java.util"
             ]
         }


### PR DESCRIPTION
As discussed in #4 access of `java.lang` should always be allowed without any configuration