### PR TITLE
#11 Refactoring tree visitor to invoke a pluggable task (validate vs.…

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -47,7 +47,7 @@
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-Xplugin:Deptective</arg>
-                        <arg>-Adeptective.reportingpolicy=WARN</arg>
+                        <arg>-Adeptective.reporting_policy=WARN</arg>
 <!--                         <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044</arg> -->
                     </compilerArgs>
                     <annotationProcessorPaths>

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveOptions.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/DeptectiveOptions.java
@@ -74,4 +74,18 @@ public class DeptectiveOptions {
             return ReportingPolicy.WARN;
         }
     }
+
+    /**
+     * Returns the task to be performed by the plug-in.
+     */
+    public PluginTask getPluginTask() {
+        String mode = options.get("deptective.mode");
+
+        if (mode != null) {
+            return PluginTask.valueOf(mode.trim().toUpperCase());
+        }
+        else {
+            return PluginTask.VALIDATE;
+        }
+    }
 }

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/PackageReferenceHandler.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/PackageReferenceHandler.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.internal;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+
+/**
+ * Implementations are invoked when traversing the ASTs of the project under compilation.
+ *
+ * @author Gunnar Morling
+ */
+public interface PackageReferenceHandler {
+
+    /**
+     * Whether the plug-ins configuration is valid for the given handler. If that's
+     * not the case, ASTs won't be traversed.
+     */
+    public boolean configIsValid();
+
+    /**
+     * Invoked when entering a new compilation unit.
+     */
+    void onEnteringCompilationUnit(CompilationUnitTree tree);
+
+    /**
+     * Invoked when referencing a package.
+     *
+     * @param referencingNode       the node referencing the other package, e.g. a
+     *                              variable or field.
+     * @param referencedPackageName the name of the referenced package
+     */
+    void onPackageReference(Tree referencingNode, String referencedPackageName);
+}

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/PackageReferenceValidator.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/PackageReferenceValidator.java
@@ -1,0 +1,178 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.StandardLocation;
+
+import org.moditect.deptective.internal.model.ConfigParser;
+import org.moditect.deptective.internal.model.Package;
+import org.moditect.deptective.internal.model.PackageDependencies;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Log;
+
+/**
+ * Validates a project's package relationships against a given description of
+ * allowed references in {@code deptective.json}.
+ *
+ * @author Gunnar Morling
+ */
+public class PackageReferenceValidator implements PackageReferenceHandler {
+
+    private final Log log;
+    private final PackageDependencies packageDependencies;
+    private final ReportingPolicy reportingPolicy;
+    private final ReportingPolicy unconfiguredPackageReportingPolicy;
+    private final Map<String, Boolean> reportedUnconfiguredPackages;
+
+    private Package currentPackage;
+
+    public PackageReferenceValidator(Context context, Optional<Path> configFile,
+            ReportingPolicy reportingPolicy, ReportingPolicy unconfiguredPackageReportingPolicy) {
+        this.log = context.get(Log.logKey);
+        this.packageDependencies = getConfig(configFile, context);
+        this.reportingPolicy = reportingPolicy;
+        this.unconfiguredPackageReportingPolicy = unconfiguredPackageReportingPolicy;
+        this.reportedUnconfiguredPackages = new HashMap<>();
+    }
+
+    @Override
+    public boolean configIsValid() {
+        if (packageDependencies == null) {
+            log.error(DeptectiveMessages.NO_DEPTECTIVE_CONFIG_FOUND);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void onEnteringCompilationUnit(CompilationUnitTree tree) {
+        ExpressionTree packageNameTree = tree.getPackageName();
+
+        // TODO deal with default package
+        if (packageNameTree == null) {
+            return;
+        }
+
+        String packageName = packageNameTree.toString();
+        currentPackage = packageDependencies.getPackage(packageName);
+
+        if (!currentPackage.isConfigured()) {
+            reportUnconfiguredPackageIfNeeded(tree, packageName);
+        }
+    }
+
+    @Override
+    public void onPackageReference(Tree referencingNode, String referencedPackageName) {
+        com.sun.tools.javac.tree.JCTree jcTree = (com.sun.tools.javac.tree.JCTree)referencingNode;
+
+        if ("java.lang".equals(referencedPackageName)) {
+            return;
+        }
+
+        if (packageDependencies.isWhitelisted(referencedPackageName)) {
+            return;
+        }
+
+        if (!currentPackage.isConfigured()) {
+            return;
+        }
+
+        if (currentPackage.getName().equals(referencedPackageName)) {
+            return;
+        }
+
+        if (referencedPackageName.isEmpty() || currentPackage.reads(referencedPackageName)) {
+            return;
+        }
+
+        if (reportingPolicy == ReportingPolicy.ERROR) {
+            log.error(jcTree.pos, DeptectiveMessages.ILLEGAL_PACKAGE_DEPENDENCY, currentPackage, referencedPackageName);
+        }
+        else {
+            log.strictWarning(jcTree, DeptectiveMessages.ILLEGAL_PACKAGE_DEPENDENCY, currentPackage, referencedPackageName);
+        }
+    }
+
+    private void reportUnconfiguredPackageIfNeeded(CompilationUnitTree tree, String packageName) {
+        boolean reportedBefore = Boolean.TRUE.equals(reportedUnconfiguredPackages.get(packageName));
+
+        if (!reportedBefore) {
+            com.sun.tools.javac.tree.JCTree jcTree = (com.sun.tools.javac.tree.JCTree)tree;
+
+            if (unconfiguredPackageReportingPolicy == ReportingPolicy.ERROR) {
+                log.error(jcTree.pos, DeptectiveMessages.PACKAGE_NOT_CONFIGURED, packageName);
+            }
+            else {
+                log.strictWarning(jcTree, DeptectiveMessages.PACKAGE_NOT_CONFIGURED, packageName);
+            }
+
+            reportedUnconfiguredPackages.put(packageName, true);
+        }
+    }
+
+    private PackageDependencies getConfig(Optional<Path> configFile, Context context) {
+        try {
+            InputStream inputStream = getConfigStream(configFile, context);
+
+            if (inputStream == null) {
+                return null;
+            }
+
+            try (InputStream is = inputStream) {
+                return new ConfigParser(is).getPackageDependencies();
+            }
+        }
+        catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private InputStream getConfigStream(Optional<Path> configFile, Context context) {
+        try {
+            if (configFile.isPresent()) {
+                    return Files.newInputStream(configFile.get());
+            }
+            else {
+                JavaFileManager jfm = context.get(JavaFileManager.class);
+                FileObject file = jfm.getFileForInput(StandardLocation.SOURCE_PATH, "", "deptective.json");
+
+                if (file != null) {
+                    return file.openInputStream();
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to load Deptective configuration file", e);
+        }
+
+        return null;
+    }
+}

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/PluginTask.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/PluginTask.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.internal;
+
+import com.sun.tools.javac.util.Context;
+
+/**
+ * Describes the {@link PackageReferenceHandler} to be invoked when traversing
+ * the ASTs of the project under compilation.
+ *
+ * @author Gunnar Morling
+ */
+public enum PluginTask {
+
+    VALIDATE {
+        @Override
+        public PackageReferenceHandler getPackageReferenceHandler(DeptectiveOptions options, Context context) {
+            return new PackageReferenceValidator(
+                    context,
+                    options.getConfigFilePath(),
+                    options.getReportingPolicy(),
+                    options.getUnconfiguredPackageReportingPolicy()
+          );
+        }
+//    },
+//    ANALYZE {
+//        @Override
+//        public PackageReferenceHandler getPackageReferenceHandler(DeptectiveOptions options, Context context) {
+//            return new PackageReferenceCollector();
+//        }
+    };
+
+    public abstract PackageReferenceHandler getPackageReferenceHandler(DeptectiveOptions options, Context context);
+}


### PR DESCRIPTION
… analyze)

@nilshartmann Here's some ground work for that alternative work mode that generates the _deptective.json_ file for an existing code base. Essentially I've reworked the listener so it takes a configurable event handler that is invoked while the AST is traversed. The existing implementation has been extracted into one implementation of this interface.

I'm now working on the alternative implementation for creating the config file, but I'd suggest you merge this one and take it as a basis for your own work.

PS: Can you please do rebases instead of merges, if possible? I refer rebases as they keep the history linear and thus easier to grok. Thanks!