### PR TITLE
#28 Allowing to pre-define components during analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,14 @@ See [integration-test/build.gradle](build.gradle) for a complete example.
 * `-Adeptective.mode=(ANALYZE|VALIDATE)`: Whether the plug-in should validate the packages of the compiled package against the _deptective.json_ file (`VALIDATE`) or whether it should generate a template for that file based on the current actual package relationships (`ANALYZE`).
 The latter can be useful when introducing Deptective into an existing code base where writing the configuration from scratch might be too tedious. Generating the configuration from the current "is" state and iteratively refining it into an intended target state can be a useful approach in that case.
 The generated JSON/DOT files are created in the compiler's class output path, e.g. _target/classes_ in case of Maven. Defaults to `VALIDATE`
-* `-Adeptective.whitelisted=...`: A comma-separated list of whitelist package patterns which will be applied in `ANALYZE` mode. Any reference to a whitelisted package will then not be added to the `reads` section of the referencing package in the generated descriptor template.
+* `-Adeptective.whitelisted=...`: An optional comma-separated list of whitelist package patterns which will be applied in `ANALYZE` mode. Any reference to a whitelisted package will then not be added to the `reads` section of the referencing package in the generated descriptor template.
 The special value `*ALL_EXTERNAL*` can be used to automatically whitelist all packages which are not part of the current compilation (i.e. packages from dependencies). This can be useful if you're only interested in managing the relationships amongst the current project's packages themselves but not the relationships to external packages.
+* `-Adeptective.components=...`: A optional semicolon-separated list of component definitions which will be applied in `ANALYZE` mode.
+This is helpful when creating the Deptective configuration for an existing code base,
+where examining relationships on the package level would be too detailed otherwise.
+Component definitions are given in the form "<name>:<package pattern 1>, <package pattern 2>, ...".
+Any package matching a component will not be added by itself to the generate configuration but to the `contains` section of the matching component.
+Example value: "foo:com.example.foo1,com.example.foo2;bar:com.example.bar*;qux:com.example.qux".
 * `-Adeptective.visualize=(true|false)`: Whether to create a GraphVize (DOT) file representing generated configuration template (in `ANALYZE` mode) or the dependency configuration and (if present) any illegal package dependencies (in `VALIDATE` mode). Defaults to `false`
 
 ### Obtaining Deptective via Jitpack

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/PluginTask.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/PluginTask.java
@@ -15,7 +15,9 @@
  */
 package org.moditect.deptective.internal;
 
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.tools.JavaFileManager;
 
@@ -23,6 +25,8 @@ import org.moditect.deptective.internal.handler.PackageReferenceCollector;
 import org.moditect.deptective.internal.handler.PackageReferenceHandler;
 import org.moditect.deptective.internal.handler.PackageReferenceValidator;
 import org.moditect.deptective.internal.log.Log;
+import org.moditect.deptective.internal.model.Component;
+import org.moditect.deptective.internal.model.Components;
 import org.moditect.deptective.internal.model.PackageDependencies;
 import org.moditect.deptective.internal.options.DeptectiveOptions;
 
@@ -54,10 +58,21 @@ public enum PluginTask {
         @Override
         public PackageReferenceHandler getPackageReferenceHandler(JavaFileManager jfm, DeptectiveOptions options,
                 Supplier<PackageDependencies> configSupplier, Log log) {
+
+            Set<Component> components = options.getComponentPackagePatterns()
+                    .entrySet()
+                    .stream()
+                    .map(e -> new Component.Builder(e.getKey())
+                            .addContains(e.getValue())
+                            .build()
+                    )
+                    .collect(Collectors.toSet());
+
             return new PackageReferenceCollector(
                     jfm,
                     log,
                     options.getWhitelistedPackagePatterns(),
+                    new Components(components),
                     options.createDotFile()
             );
         }

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/handler/PackageReferenceValidator.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/handler/PackageReferenceValidator.java
@@ -50,7 +50,7 @@ public class PackageReferenceValidator implements PackageReferenceHandler {
     private final PackageDependencies allowedPackageDependencies;
     private final JavaFileManager jfm;
     private final ReportingPolicy reportingPolicy;
-    private final boolean createDotFile;
+    private boolean createDotFile;
     private final ReportingPolicy unconfiguredPackageReportingPolicy;
     private final Map<String, Boolean> reportedUnconfiguredPackages;
 
@@ -116,6 +116,7 @@ public class PackageReferenceValidator implements PackageReferenceHandler {
                     packageName
             );
 
+            createDotFile = false;
             return false;
         }
 

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/model/Components.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/model/Components.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.internal.model;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A set of {@link Component}s.
+ *
+ * @author Gunnar Morling
+ */
+public class Components implements Iterable<Component> {
+
+    private final Set<Component> contained;
+    private final Map<String, Component> componentsByPackage;
+
+    public Components(Set<Component> contained) {
+        this.contained = Collections.unmodifiableSet(contained);
+        this.componentsByPackage = new HashMap<>();
+    }
+
+    @Override
+    public Iterator<Component> iterator() {
+        return contained.iterator();
+    }
+
+    public Stream<Component> stream() {
+        return contained.stream();
+    }
+
+    /**
+     * Returns the component containing the given package or {@code null} if no such component exists.
+     *
+     * @throws PackageAssignedToMultipleComponentsException In case more than one component was found whose filter
+     *         expressions match the given package.
+     */
+    public Component getComponentByPackage(String qualifiedName) throws PackageAssignedToMultipleComponentsException {
+        if (qualifiedName == null || qualifiedName.isEmpty()) {
+            return null;
+        }
+
+        return componentsByPackage.computeIfAbsent(
+                qualifiedName,
+                p -> {
+                    Set<Component> candidates = contained.stream()
+                            .filter(c -> c.containsPackage(p))
+                            .collect(Collectors.toSet());
+
+                    if (candidates.isEmpty()) {
+                        return null;
+                    }
+                    else if (candidates.size() == 1) {
+                        return candidates.iterator().next();
+                    }
+                    else {
+                        throw new PackageAssignedToMultipleComponentsException(candidates);
+                    }
+                }
+        );
+    }
+}

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/model/PackagePattern.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/model/PackagePattern.java
@@ -27,10 +27,13 @@ public class PackagePattern implements Comparable<PackagePattern> {
 
     private static final String ALL_EXTERNAL_PATTERN = "*ALL_EXTERNAL*";
     public static final PackagePattern ALL_EXTERNAL = new PackagePattern(ALL_EXTERNAL_PATTERN);
-    private final Pattern pattern;
+
+    private final String pattern;
+    private final Pattern regex;
 
     private PackagePattern(String pattern) {
-        this.pattern = Pattern.compile(pattern.replace("*", ".*"));
+        this.pattern = pattern;
+        this.regex = Pattern.compile(pattern.replace("*", ".*"));
     }
 
     public static PackagePattern getPattern(String pattern) {
@@ -43,24 +46,24 @@ public class PackagePattern implements Comparable<PackagePattern> {
     }
 
     public boolean matches(String packageName) {
-        return pattern.matcher(packageName).matches();
+        return regex.matcher(packageName).matches();
     }
 
     @Override
     public String toString() {
-        return pattern.pattern();
+        return pattern;
     }
 
     @Override
     public int compareTo(PackagePattern o) {
-        return pattern.pattern().compareTo(o.pattern.pattern());
+        return pattern.compareTo(o.pattern);
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((pattern == null) ? 0 : pattern.pattern().hashCode());
+        result = prime * result + pattern.hashCode();
         return result;
     }
 
@@ -73,12 +76,7 @@ public class PackagePattern implements Comparable<PackagePattern> {
         if (getClass() != obj.getClass())
             return false;
         PackagePattern other = (PackagePattern) obj;
-        if (pattern == null) {
-            if (other.pattern != null)
-                return false;
-        }
-        else if (!pattern.pattern().equals(other.pattern.pattern()))
-            return false;
-        return true;
+
+        return pattern.equals(other.pattern);
     }
 }

--- a/javac-plugin/src/main/java/org/moditect/deptective/internal/options/DeptectiveOptions.java
+++ b/javac-plugin/src/main/java/org/moditect/deptective/internal/options/DeptectiveOptions.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -112,6 +113,31 @@ public class DeptectiveOptions {
         }
         else {
             return Collections.emptyList();
+        }
+    }
+
+    public Map<String, List<PackagePattern>> getComponentPackagePatterns() {
+        String components = options.get("deptective.components");
+
+        if (components != null) {
+            Map<String, List<PackagePattern>> componentPatterns = new HashMap<String, List<PackagePattern>>();
+            String[] patterns = components.split(";");
+
+            for (String patternsForComponent : patterns) {
+                String[] componentAndPatterns = patternsForComponent.split(":");
+                String component = componentAndPatterns[0];
+                List<PackagePattern> patternsOfComponent = Arrays.stream(componentAndPatterns[1].split(","))
+                        .map(String::trim)
+                        .map(PackagePattern::getPattern)
+                        .collect(Collectors.toList());
+
+                componentPatterns.put(component, patternsOfComponent);
+            }
+
+            return componentPatterns;
+        }
+        else {
+            return Collections.emptyMap();
         }
     }
 }

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/AnalyzeWithDefinedComponentsTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/AnalyzeWithDefinedComponentsTest.java
@@ -1,0 +1,109 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.moditect.deptective.internal.util.Strings.lines;
+
+import java.util.Optional;
+
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+import org.junit.Test;
+import org.moditect.deptective.internal.util.Strings;
+import org.moditect.deptective.plugintest.PluginTestBase;
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.Bar;
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub1.BarSub1;
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub2.BarSub2;
+import org.moditect.deptective.plugintest.analyzewithcomponent.foo.Foo;
+import org.moditect.deptective.plugintest.analyzewithcomponent.qux.Qux;
+import org.moditect.deptective.plugintest.analyzewithcomponent.qux.quxsub1.QuxSub1;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+
+public class AnalyzeWithDefinedComponentsTest extends PluginTestBase {
+
+    @Test
+    public void shouldGenerateConfig() throws Exception {
+        Compilation compilation = Compiler.javac()
+                .withOptions(
+                        "-Xplugin:Deptective",
+                        "-Adeptective.mode=ANALYZE",
+                        "-Adeptective.whitelisted=*ALL_EXTERNAL*",
+                        "-Adeptective.components=" +
+                                "bar:org.moditect.deptective.plugintest.analyzewithcomponent.bar," +
+                                "org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub*;" +
+                                "qux:org.moditect.deptective.plugintest.analyzewithcomponent.qux*"
+                )
+                .compile(
+                        forTestClass(Bar.class),
+                        forTestClass(BarSub1.class),
+                        forTestClass(BarSub2.class),
+                        forTestClass(Foo.class),
+                        forTestClass(Qux.class),
+                        forTestClass(QuxSub1.class)
+                );
+
+        assertThat(compilation).succeeded();
+
+        assertThat(compilation).hadNoteContaining(
+                "Generated Deptective configuration template at mem:///CLASS_OUTPUT/deptective.json"
+        );
+        assertThat(compilation).hadNoteCount(1);
+
+        String expectedConfig = lines(
+                "{",
+                "    \"components\": [",
+                "        {",
+                "            \"name\": \"bar\",",
+                "            \"contains\": [",
+                "                \"org.moditect.deptective.plugintest.analyzewithcomponent.bar\",",
+                "                \"org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub*\"",
+                "            ]",
+                "        },",
+                "        {",
+                "            \"name\": \"org.moditect.deptective.plugintest.analyzewithcomponent.foo\",",
+                "            \"contains\": [",
+                "                \"org.moditect.deptective.plugintest.analyzewithcomponent.foo\"",
+                "            ],",
+                "            \"reads\": [",
+                "                \"bar\",",
+                "                \"qux\"",
+                "            ]",
+                "        },",
+                "        {",
+                "            \"name\": \"qux\",",
+                "            \"contains\": [",
+                "                \"org.moditect.deptective.plugintest.analyzewithcomponent.qux*\"",
+                "            ]",
+                "        }",
+                "    ]",
+                "}"
+        );
+
+        Optional<JavaFileObject> deptectiveFile = compilation
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "deptective.json");
+        assertThat(deptectiveFile.isPresent()).isTrue();
+        String generatedConfig = Strings.readToString(deptectiveFile.get().openInputStream());
+
+        JSONAssert.assertEquals(expectedConfig, generatedConfig, JSONCompareMode.LENIENT);
+    }
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/Bar.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/Bar.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.bar;
+
+import java.io.File;
+
+public class Bar {
+
+    private File file;
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/barsub1/BarSub1.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/barsub1/BarSub1.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub1;
+
+import java.io.File;
+
+public class BarSub1 {
+
+    private File file;
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/barsub2/BarSub2.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/bar/barsub2/BarSub2.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub2;
+
+import java.io.File;
+
+public class BarSub2 {
+
+    private File file;
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/foo/Foo.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/foo/Foo.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.foo;
+
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.Bar;
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub1.BarSub1;
+import org.moditect.deptective.plugintest.analyzewithcomponent.bar.barsub2.BarSub2;
+import org.moditect.deptective.plugintest.analyzewithcomponent.qux.Qux;
+import org.moditect.deptective.plugintest.analyzewithcomponent.qux.quxsub1.QuxSub1;
+
+public class Foo {
+
+    private final Bar bar = new Bar();
+    private final BarSub1 barSub1 = new BarSub1();
+    private final BarSub2 barSub2 = new BarSub2();
+    private final Qux qux = new Qux();
+    private final QuxSub1 quxSub1 = new QuxSub1();
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/qux/Qux.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/qux/Qux.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.qux;
+
+import java.io.File;
+
+public class Qux {
+
+    private File file;
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/qux/quxsub1/QuxSub1.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/analyzewithcomponent/qux/quxsub1/QuxSub1.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.analyzewithcomponent.qux.quxsub1;
+
+import java.io.File;
+
+public class QuxSub1 {
+
+    private File file;
+}

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/packagecontainedtwiceanalyze/AnalyzeWithDefinedComponentsTest.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/packagecontainedtwiceanalyze/AnalyzeWithDefinedComponentsTest.java
@@ -13,34 +13,35 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.moditect.deptective.plugintest.packagecontainedtwice;
+package org.moditect.deptective.plugintest.packagecontainedtwiceanalyze;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 
 import org.junit.Test;
 import org.moditect.deptective.plugintest.PluginTestBase;
-import org.moditect.deptective.plugintest.packagecontainedtwice.foo.Foo;
+import org.moditect.deptective.plugintest.packagecontainedtwiceanalyze.foo.Foo;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 
-public class PackageContainedInTwoComponentsTest extends PluginTestBase {
+public class AnalyzeWithDefinedComponentsTest extends PluginTestBase {
 
     @Test
-    public void shouldFailWhenSamePackageIsContainedInMultipleComponents() {
+    public void shouldFailUponAnalyzeWithPackageMatchedByMultipleComponents() throws Exception {
         Compilation compilation = Compiler.javac()
                 .withOptions(
                         "-Xplugin:Deptective",
-                        getConfigFileOption()
+                        "-Adeptective.mode=ANALYZE",
+                        "-Adeptective.components=" +
+                                "foo1:org.moditect.deptective.plugintest.packagecontainedtwiceanalyze.foo;" +
+                                "foo2:org.moditect.deptective.plugintest.packagecontainedtwiceanalyze.foo"
                 )
-                .compile(
-                        forTestClass(Foo.class)
-                );
+                .compile(forTestClass(Foo.class));
 
         assertThat(compilation).failed();
         assertThat(compilation).hadNoteCount(0);
         assertThat(compilation).hadErrorContaining(
-                "Multiple components match package org.moditect.deptective.plugintest.packagecontainedtwice.foo: foo1, foo2"
+                "Multiple components match package org.moditect.deptective.plugintest.packagecontainedtwiceanalyze.foo: foo1, foo2"
         );
     }
 }

--- a/javac-plugin/src/test/java/org/moditect/deptective/plugintest/packagecontainedtwiceanalyze/foo/Foo.java
+++ b/javac-plugin/src/test/java/org/moditect/deptective/plugintest/packagecontainedtwiceanalyze/foo/Foo.java
@@ -1,0 +1,19 @@
+/**
+ *  Copyright 2019 The ModiTect authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.moditect.deptective.plugintest.packagecontainedtwiceanalyze.foo;
+
+public class Foo {
+}


### PR DESCRIPTION
@wuetherich, @nilshartmann, this adds support for pre-defining components in "analyze" mode. I.e. when generating the Deptective configuration for an existing code base, this allows you to not add each package individually but group them into pre-defined components. That way you can "capture" e.g. all "model" packages into a "model" component of the generated descriptor.

I think this makes it quite a good tool when it comes to adding Deptective to existing code bases. Let me know what you think. I'll focus on Gerd's cycles PR next.